### PR TITLE
fix: resolve Dependabot vulnerabilities and Codacy stylelint issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ Thumbs.db
 .codecov
 
 CHANGELOG.md
+
+# CodeGraph local database
+.codegraph/

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
         "git-cliff": "^2.8.0",
         "jasmine-core": "^6.3.0",
         "jsdom": "^29.1.1",
-        "postcss": "^8.5.20",
+        "postcss": "^8.5.23",
         "stylelint": "^16.24.0",
         "stylelint-config-standard-scss": "^16.0.0",
         "stylelint-no-unsupported-browser-features": "^8.0.0",
@@ -16276,9 +16276,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
-      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "dev": true,
       "funding": [
         {
@@ -16296,7 +16296,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package-lock.json
+++ b/package-lock.json
@@ -8267,16 +8267,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/codecov/node_modules/argparse": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
-      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sprintf-js": "~1.0.2"
-      }
-    },
     "node_modules/codecov/node_modules/brace-expansion": {
       "version": "1.1.18",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.18.tgz",
@@ -8296,20 +8286,6 @@
       "license": "ISC",
       "dependencies": {
         "minimatch": "^3.0.4"
-      }
-    },
-    "node_modules/codecov/node_modules/js-yaml": {
-      "version": "3.14.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
-      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^1.0.7",
-        "esprima": "^4.0.0"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/codecov/node_modules/minimatch": {
@@ -12663,9 +12639,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.1.tgz",
+      "integrity": "sha512-1e9d3kb97NHJTIJDZW9rKqW2h6+dFa50Dy0fpPSMQp2ADje5gvKsXmdiK6dwY5t76TaTt5+P5N1Y/LoToIxP6g==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -13460,9 +13436,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -15114,9 +15090,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -18324,13 +18300,6 @@
       "engines": {
         "node": "*"
       }
-    },
-    "node_modules/sprintf-js": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
-      "dev": true,
-      "license": "BSD-3-Clause"
     },
     "node_modules/sshpk": {
       "version": "1.18.0",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     "git-cliff": "^2.8.0",
     "jasmine-core": "^6.3.0",
     "jsdom": "^29.1.1",
-    "postcss": "^8.5.20",
+    "postcss": "^8.5.23",
     "stylelint": "^16.24.0",
     "stylelint-config-standard-scss": "^16.0.0",
     "stylelint-no-unsupported-browser-features": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,11 @@
     "typescript-eslint": "^8.64.0",
     "vitest": "^4.1.10"
   },
+  "overrides": {
+    "nanoid": "3.3.17",
+    "js-yaml": "4.3.1",
+    "ip-address": "10.3.1"
+  },
   "cypress-cucumber-preprocessor": {
     "stepDefinitions": [
       "cypress/e2e/**/*.ts",

--- a/src/app/shared/components/navigation/navigation.component.css
+++ b/src/app/shared/components/navigation/navigation.component.css
@@ -5,7 +5,6 @@
   z-index: 100;
   background-color: var(--color-glass-bg);
   backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
   border-bottom: 1px solid var(--color-border-hairline);
   font-family: var(--font-jetbrains);
   transition: all 0.3s ease;
@@ -53,7 +52,7 @@
 .nav-link:hover, .active-link {
   color: var(--color-terminal-green);
   font-weight: 700;
-  background-color: rgba(16, 185, 129, 0.08);
+  background-color: rgb(16 185 129 / 8%);
 }
 
 /* ===== Live Status Badge ===== */
@@ -64,8 +63,8 @@
   color: #4ade80;
   font-weight: bold;
   font-size: 12px;
-  background-color: rgba(16, 185, 129, 0.1);
-  border: 1px solid rgba(16, 185, 129, 0.2);
+  background-color: rgb(16 185 129 / 10%);
+  border: 1px solid rgb(16 185 129 / 20%);
   padding: 4px 12px;
   border-radius: 9999px;
   letter-spacing: 0.1em;
@@ -75,7 +74,7 @@
 }
 
 .live-status:hover {
-  background-color: rgba(16, 185, 129, 0.2);
+  background-color: rgb(16 185 129 / 20%);
   transform: translateY(-1px);
 }
 
@@ -92,6 +91,7 @@
   0%, 100% {
     opacity: 1;
   }
+
   50% {
     opacity: .5;
   }
@@ -115,7 +115,7 @@
 
 .mobile-menu-btn:hover {
   border-color: var(--color-terminal-green);
-  background-color: rgba(16, 185, 129, 0.05);
+  background-color: rgb(16 185 129 / 5%);
 }
 
 .hamburger-line {
@@ -143,9 +143,9 @@
 .mobile-overlay {
   position: fixed;
   inset: 0;
-  background-color: rgba(0, 0, 0, 0.65);
+  background-color: rgb(0 0 0 / 65%);
   z-index: 90;
-  animation: fadeIn 0.2s ease;
+  animation: fade-in 0.2s ease;
 }
 
 .mobile-dropdown {
@@ -154,13 +154,12 @@
   left: 0;
   right: 0;
   z-index: 95;
-  background-color: rgba(18, 19, 22, 0.95);
+  background-color: rgb(18 19 22 / 95%);
   border-bottom: 1px solid var(--color-border-hairline);
   padding: 12px 0;
-  animation: slideDown 0.25s ease;
+  animation: slide-down 0.25s ease;
   backdrop-filter: blur(16px);
-  -webkit-backdrop-filter: blur(16px);
-  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.3);
+  box-shadow: 0 10px 25px rgb(0 0 0 / 30%);
 }
 
 .mobile-dropdown-link {
@@ -177,7 +176,7 @@
 .mobile-dropdown-link:hover,
 .mobile-dropdown-link.active-link {
   color: var(--color-terminal-green);
-  background-color: rgba(16, 185, 129, 0.08);
+  background-color: rgb(16 185 129 / 8%);
 }
 
 .live-status-mobile {
@@ -190,16 +189,17 @@
   padding-top: 14px;
 }
 
-@keyframes fadeIn {
+@keyframes fade-in {
   from { opacity: 0; }
   to { opacity: 1; }
 }
 
-@keyframes slideDown {
+@keyframes slide-down {
   from {
     opacity: 0;
     transform: translateY(-8px);
   }
+
   to {
     opacity: 1;
     transform: translateY(0);
@@ -214,15 +214,14 @@
   left: 0;
   right: 0;
   z-index: 100;
-  background-color: rgba(13, 14, 17, 0.92);
-  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  background-color: rgb(13 14 17 / 92%);
+  border-top: 1px solid rgb(255 255 255 / 8%);
   backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   justify-content: space-around;
   align-items: center;
   padding: 6px 0;
   padding-bottom: calc(6px + env(safe-area-inset-bottom, 0px));
-  box-shadow: 0 -4px 20px rgba(0, 0, 0, 0.4);
+  box-shadow: 0 -4px 20px rgb(0 0 0 / 40%);
 }
 
 .mobile-nav-item {
@@ -253,7 +252,7 @@
 .mobile-nav-item:hover,
 .mobile-nav-item.mobile-nav-active {
   color: var(--color-terminal-green);
-  background-color: rgba(16, 185, 129, 0.08);
+  background-color: rgb(16 185 129 / 8%);
 }
 
 .mobile-nav-item.mobile-nav-active i {
@@ -270,7 +269,7 @@
   display: none;
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .nav-container {
     padding: 14px var(--spacing-gutter);
   }

--- a/src/app/shared/components/skills-matrix/skills-matrix.component.css
+++ b/src/app/shared/components/skills-matrix/skills-matrix.component.css
@@ -29,7 +29,7 @@
   color: var(--color-outline);
 }
 
-@media (max-width: 768px) {
+@media (width <= 768px) {
   .skill-row {
     flex-direction: column;
     margin-bottom: var(--spacing-stack-md);


### PR DESCRIPTION
## Summary

Resolves the security and code-quality blockers before the release → main merge.

### 1. Dependabot vulnerabilities (high severity)
Added npm `overrides` to force patched versions of vulnerable transitive dependencies:
- **nanoid** `3.3.16` → `3.3.17` (runtime, high)
- **js-yaml** `4.3.0` → `4.3.1` (dev, high)
- **ip-address** `10.2.0` → `10.3.1` (dev, high)

These clear Dependabot alerts #181, #180, #179, #178, #171.

### 2. Codacy Stylelint issues (42)
Fixed all 42 Info-severity Stylelint findings in `navigation.component.css` and `skills-matrix.component.css`:
- Modern `rgb()` color-function notation (with alpha as percentages)
- `alpha-value-notation` → percentage form
- Removed duplicate `backdrop-filter` declarations and `-webkit-` vendor prefixes
- Kebab-case keyframe names (`fadeIn` → `fade-in`, `slideDown` → `slide-down`)

### 3. Housekeeping
- Ignore local `.codegraph/` database (was accidentally tracked)

## Verification
- `npm run lint` ✅
- `npm run lint:styles` ✅
- `npm run build:staging` ✅
- `npm run test:coverage` ✅ (100% statements/lines)
