### PR TITLE
fix: home component E2E wiring and CI stage fixes

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,9 +36,9 @@ stages:
           - task: Cache@2
             displayName: Cache node_modules
             inputs:
-              key: 'node_modules | "(Agent.OS)" | package-lock.json'
+              key: 'node_modules | "$(Agent.OS)" | package-lock.json'
               restoreKeys: |
-                node_modules | "(Agent.OS)"'
+                node_modules | "$(Agent.OS)"
               path: node_modules
 
           - script: npm ci --prefer-offline --no-audit --no-fund
@@ -77,9 +77,9 @@ stages:
           - task: Cache@2
             displayName: Cache node_modules
             inputs:
-              key: 'node_modules | "(Agent.OS)" | package-lock.json'
+              key: 'node_modules | "$(Agent.OS)" | package-lock.json'
               restoreKeys: |
-                node_modules | "(Agent.OS)"'
+                node_modules | "$(Agent.OS)"
               path: node_modules
 
           - script: npm ci --prefer-offline --no-audit --no-fund

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,6 +123,7 @@ stages:
 
   - stage: E2EContactForm
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -148,7 +149,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:contact-form
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Contact Form
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -158,6 +158,7 @@ stages:
 
   - stage: E2EHome
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -183,7 +184,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:home
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Home
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -193,6 +193,7 @@ stages:
 
   - stage: E2ENavigation
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -218,7 +219,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:navigation
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Navigation
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -228,6 +228,7 @@ stages:
 
   - stage: E2EPages
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -253,7 +254,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:pages
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Pages
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -263,6 +263,7 @@ stages:
 
   - stage: E2ETerminal
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -288,7 +289,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:terminal
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Terminal
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
@@ -298,6 +298,7 @@ stages:
 
   - stage: E2ELighthouse
     dependsOn: [Init]
+    condition: ne(variables['Build.Reason'], 'PullRequest')
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -323,7 +324,6 @@ stages:
             displayName: Run npm install
 
           - script: npm run e2e:ci:lighthouse
-            condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
             displayName: Run E2E - Lighthouse
             env:
               CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,29 +26,23 @@ variables:
     publicUrl: https://staging.datariomj.dev
 
 stages:
-  - stage: Lint
+  - stage: Init
     dependsOn: []
     variables:
       CYPRESS_INSTALL_BINARY: '0'
     jobs:
-      - job: Lint
+      - job: Init
         steps:
           - task: Cache@2
             displayName: Cache node_modules
             inputs:
-              key: 'node_modules | "$(Agent.OS)" | package-lock.json'
+              key: 'node_modules | "(Agent.OS)" | package-lock.json'
               restoreKeys: |
-                node_modules | "$(Agent.OS)"
+                node_modules | "(Agent.OS)"'
               path: node_modules
 
           - script: npm ci --prefer-offline --no-audit --no-fund
             displayName: Run npm install
-          
-          - script: npm run lint
-            displayName: Run Angular lints
-          
-          - script: npm run lint:styles
-            displayName: Run style lints
 
           - script: |
               version=$(npm run changelog:version | tail -n 1 | tr -d '\n')
@@ -73,8 +67,33 @@ stages:
             condition: and(succeeded(), eq(variables['Build.Reason'], 'PullRequest'), or(eq(variables['System.PullRequest.TargetBranch'], 'refs/heads/main'), eq(variables['System.PullRequest.TargetBranch'], 'main'), eq(variables['System.PullRequest.TargetBranchName'], 'main')))
             displayName: Comment Upcoming Changelog on PR
 
+  - stage: Lint
+    dependsOn: [Init]
+    variables:
+      CYPRESS_INSTALL_BINARY: '0'
+    jobs:
+      - job: Lint
+        steps:
+          - task: Cache@2
+            displayName: Cache node_modules
+            inputs:
+              key: 'node_modules | "(Agent.OS)" | package-lock.json'
+              restoreKeys: |
+                node_modules | "(Agent.OS)"'
+              path: node_modules
+
+          - script: npm ci --prefer-offline --no-audit --no-fund
+            displayName: Run npm install
+
+          - script: npm run lint
+            displayName: Run Angular lints
+
+          - script: npm run lint:styles
+            displayName: Run style lints
+
+
   - stage: Test
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_INSTALL_BINARY: '0'
     jobs:
@@ -103,7 +122,7 @@ stages:
             displayName: Upload coverage to Codecov
 
   - stage: E2EContactForm
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -138,7 +157,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: E2EHome
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -173,7 +192,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: E2ENavigation
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -208,7 +227,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: E2EPages
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -243,7 +262,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: E2ETerminal
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -278,7 +297,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: E2ELighthouse
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_CACHE_FOLDER: $(Pipeline.Workspace)/.cypress
     jobs:
@@ -313,7 +332,7 @@ stages:
               CYPRESS_RECORD: "true"
 
   - stage: Build
-    dependsOn: []
+    dependsOn: [Init]
     variables:
       CYPRESS_INSTALL_BINARY: '0'
     jobs:


### PR DESCRIPTION
Fixes E2E tests and CI validation issues discovered after PR #73 merged.

## Fixes
- Wire  into  so E2E tests find it
- Convert parallel E2E specs into separate Azure Pipelines stages (jobs inside a single stage cannot be depended on from other stages)
- Add dedicated  stage for changelog generation and PR comment; keep Lint focused on lint/style checks only
- Disable Cypress video recording to save free-tier bandwidth

## Verification
- npm run lint ✅
- npm run lint:styles ✅
- All 6 E2E specs pass locally (28 tests total)
- azure-pipelines.yml YAML valid ✅